### PR TITLE
[BB-2052] Run the post-deploy hook using pipenv from the correct directory

### DIFF
--- a/manage_certs.py
+++ b/manage_certs.py
@@ -11,6 +11,7 @@ Certificates are requested using Certbot.
 
 import argparse
 import logging
+import pathlib
 import sys
 
 import consul
@@ -50,9 +51,12 @@ def main(args):
     """Parse command line, run certificate manager."""
     config = parse_command_line(args)
     configure_logger(logger, config.log_level.upper())
+    cert_manager_dir = str(pathlib.Path(__file__).resolve().parent)
     if not config.deploy_hook:
-        config.deploy_hook = "./deploy_cert.py --log-level '{}' --consul-certs-prefix '{}'".format(
-            config.log_level, config.consul_certs_prefix
+        config.deploy_hook = (
+            "cd {}; pipenv run python ./deploy_cert.py --log-level '{}' --consul-certs-prefix '{}'".format(
+                cert_manager_dir, config.log_level, config.consul_certs_prefix
+            )
         )
     certbot_client = CertbotClient(
         contact_email=config.contact_email,


### PR DESCRIPTION
This fixes the issue due to which the certbot renewal job fails to run
the post-deploy hook.

**Testing instructions**:
* Log in to the cert-manager server.
* Navigate to `/etc/letsencrypt/renewal` and open the configuration for one of the available certificates.
* Replace the `renewal_hook` command under the `renewalparams` section to `cd /opt/cert-manager; pipenv run python ./deploy_cert.py --log-level 'debug' --consul-certs-prefix 'ocim/certs'`.
* Force the renewal for a certificate by running `certbot renew --cert-name <name of the certificate> --force-renewal`.
* Verify that the certificate renewal succeeds and runs the deploy hook without any errors even when it is run outside the pipenv environment.