### PR TITLE
BB-2231: Disable partial provisioning of certificates

### DIFF
--- a/cert_manager/certbot.py
+++ b/cert_manager/certbot.py
@@ -25,7 +25,6 @@ class CertbotClient:
             "--non-interactive",
             "--agree-tos",
             "--keep",
-            "--allow-subset-of-names",
             "--deploy-hook", self.deploy_hook,
             "--cert-name", domains[0],
         ]


### PR DESCRIPTION
This PR removes the `--allow-subset-of-names` parameter when invoking certbot, this prevents certificates to be partially provisioned.