### PR TITLE
SE-2197: Pin mock and python versions to match production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,17 +12,17 @@ jobs:
     steps:
       - checkout
       - run: 
-          name: Install pipenv globally
-          command: pip install pipenv
+          name: Install pipenv locally
+          command: pip install --user pipenv
       - restore_cache:
           key: dependencies-{{ checksum "Pipfile.lock" }}
       - run:
           name: Set up pipenv and install requirements.
-          command: pipenv install --dev --ignore-pipfile
+          command: ~/.local/bin/pipenv install --dev --ignore-pipfile
       - save_cache:
           key: dependencies-{{ checksum "Pipfile.lock" }}
           paths:
             - ".venv"
       - run:
           name: Run the tests.
-          command: pipenv run pytest
+          command: ~/.local/bin/pipenv run pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,11 @@ jobs:
           key: dependencies-{{ checksum "Pipfile.lock" }}
       - run:
           name: Set up pipenv and install requirements.
-          command: ~/.local/bin/pipenv --python /usr/bin/python3.5 install --dev --ignore-pipfile
+          command: ~/.local/bin/pipenv --python /usr/local/bin/python install --dev --ignore-pipfile
       - save_cache:
           key: dependencies-{{ checksum "Pipfile.lock" }}
           paths:
             - ".venv"
       - run:
           name: Run the tests.
-          command: ~/.local/bin/pipenv --python /usr/bin/python3.5 run pytest
+          command: ~/.local/bin/pipenv --python /usr/local/bin/python run pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
       PIPENV_VENV_IN_PROJECT: true
     steps:
       - checkout
+      - run:
+          name: Install python3 and pip3
+          command: apt-get update && apt-get install -y python3 python3-pip
       - run: 
           name: Install pipenv locally
           command: pip install --user pipenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.5.3
+      - image: ubuntu:xenial
       - image: consul:1.2.2
         environment:
           CONSUL_BIND_INTERFACE: eth0
@@ -18,11 +18,11 @@ jobs:
           key: dependencies-{{ checksum "Pipfile.lock" }}
       - run:
           name: Set up pipenv and install requirements.
-          command: ~/.local/bin/pipenv --python /usr/local/bin/python install --dev --ignore-pipfile
+          command: ~/.local/bin/pipenv install --dev --ignore-pipfile
       - save_cache:
           key: dependencies-{{ checksum "Pipfile.lock" }}
           paths:
             - ".venv"
       - run:
           name: Run the tests.
-          command: ~/.local/bin/pipenv --python /usr/local/bin/python run pytest
+          command: ~/.local/bin/pipenv run pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - checkout
       - run: 
-          name: Install pipenv
-          command: pip install --user pipenv
+          name: Install pipenv globally
+          command: pip install pipenv
       - restore_cache:
           key: dependencies-{{ checksum "Pipfile.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.5.2
+      - image: circleci/python:3.5.3
       - image: consul:1.2.2
         environment:
           CONSUL_BIND_INTERFACE: eth0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.6
+      - image: circleci/python:3.5.2
       - image: consul:1.2.2
         environment:
           CONSUL_BIND_INTERFACE: eth0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,11 @@ jobs:
           key: dependencies-{{ checksum "Pipfile.lock" }}
       - run:
           name: Set up pipenv and install requirements.
-          command: ~/.local/bin/pipenv install --dev --ignore-pipfile
+          command: ~/.local/bin/pipenv --python /usr/bin/python3.5 install --dev --ignore-pipfile
       - save_cache:
           key: dependencies-{{ checksum "Pipfile.lock" }}
           paths:
             - ".venv"
       - run:
           name: Run the tests.
-          command: ~/.local/bin/pipenv run pytest
+          command: ~/.local/bin/pipenv --python /usr/bin/python3.5 run pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
       PIPENV_VENV_IN_PROJECT: true
     steps:
       - checkout
+      - run: 
+          name: Install pipenv
+          command: pip install --user pipenv
       - restore_cache:
           key: dependencies-{{ checksum "Pipfile.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           command: apt-get update && apt-get install -y python3 python3-pip
       - run: 
           name: Install pipenv locally
-          command: pip install --user pipenv
+          command: pip3 install --user pipenv
       - restore_cache:
           key: dependencies-{{ checksum "Pipfile.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ jobs:
           CONSUL_BIND_INTERFACE: eth0
     environment:
       PIPENV_VENV_IN_PROJECT: true
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
     steps:
       - checkout
       - run:

--- a/Pipfile
+++ b/Pipfile
@@ -18,5 +18,5 @@ rope = "*"
 pytest = "*"
 
 [requires]
-# Match version on Ubuntu LTS 16.04.6
-python_version = "3.5.2"
+# Match version on Ubuntu LTS 16.04.6 as closely as possible
+python_version = "3.5"

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ pyopenssl = "~= 18.0"
 # Pin certbot and acme to the system-wide versions (see SE-2197)
 certbot = "==0.31.0"
 acme = "==0.31.0"
+mock = "==3.0.5"
 
 [dev-packages]
 pylint = "*"
@@ -17,4 +18,5 @@ rope = "*"
 pytest = "*"
 
 [requires]
-python_version = "3"
+# Match version on Ubuntu LTS 16.04.6
+python_version = "3.5.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d2d2c3b6d8d78487b524ed29235381fbe79abf9f20691c8d004311419cb46567"
+            "sha256": "e2f4583910b5a1738419da3f688025c64b3a32eaec6953e5c12ace9b9efc58b4"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.5.2"
+            "python_version": "3.5"
         },
         "sources": [
             {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -453,6 +453,14 @@
             ],
             "version": "==20.3"
         },
+        "pathlib2": {
+            "hashes": [
+                "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db",
+                "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"
+            ],
+            "markers": "python_version < '3.6'",
+            "version": "==2.3.5"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
@@ -548,10 +556,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+                "sha256:c70410551488251b0fee67b460fb9a536af8d6f9f008ad10ac51f615b6a521b1",
+                "sha256:e0d9e63797e483a30d27e09fffd308c59a700d365ec34e93cc100844168bf921"
             ],
-            "version": "==3.1.0"
+            "version": "==1.2.0"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9b9d813c4314aa6b27fe5b0157b5bab3dc9941a393dcd2835656c10d0d876a07"
+            "sha256": "d2d2c3b6d8d78487b524ed29235381fbe79abf9f20691c8d004311419cb46567"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3"
+            "python_version": "3.5.2"
         },
         "sources": [
             {
@@ -34,10 +34,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
-                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
+                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
             ],
-            "version": "==2019.11.28"
+            "version": "==2020.4.5.1"
         },
         "cffi": {
             "hashes": [
@@ -81,9 +81,9 @@
         },
         "configargparse": {
             "hashes": [
-                "sha256:7971cdb14328baaada0f140832925de83ecee93ac5e67e587e3476fac283ad51"
+                "sha256:024e036ff1b3fa807b826414681e3d67ffa61c692e83b320157a665dd7889f49"
             ],
-            "version": "==1.1"
+            "version": "==1.2"
         },
         "configobj": {
             "hashes": [
@@ -93,29 +93,27 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:02079a6addc7b5140ba0825f542c0869ff4df9a69c360e339ecead5baefa843c",
-                "sha256:1df22371fbf2004c6f64e927668734070a8953362cd8370ddd336774d6743595",
-                "sha256:369d2346db5934345787451504853ad9d342d7f721ae82d098083e1f49a582ad",
-                "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651",
-                "sha256:44ff04138935882fef7c686878e1c8fd80a723161ad6a98da31e14b7553170c2",
-                "sha256:4b1030728872c59687badcca1e225a9103440e467c17d6d1730ab3d2d64bfeff",
-                "sha256:58363dbd966afb4f89b3b11dfb8ff200058fbc3b947507675c19ceb46104b48d",
-                "sha256:6ec280fb24d27e3d97aa731e16207d58bd8ae94ef6eab97249a2afe4ba643d42",
-                "sha256:7270a6c29199adc1297776937a05b59720e8a782531f1f122f2eb8467f9aab4d",
-                "sha256:73fd30c57fa2d0a1d7a49c561c40c2f79c7d6c374cc7750e9ac7c99176f6428e",
-                "sha256:7f09806ed4fbea8f51585231ba742b58cbcfbfe823ea197d8c89a5e433c7e912",
-                "sha256:90df0cc93e1f8d2fba8365fb59a858f51a11a394d64dbf3ef844f783844cc793",
-                "sha256:971221ed40f058f5662a604bd1ae6e4521d84e6cad0b7b170564cc34169c8f13",
-                "sha256:a518c153a2b5ed6b8cc03f7ae79d5ffad7315ad4569b2d5333a13c38d64bd8d7",
-                "sha256:b0de590a8b0979649ebeef8bb9f54394d3a41f66c5584fff4220901739b6b2f0",
-                "sha256:b43f53f29816ba1db8525f006fa6f49292e9b029554b3eb56a189a70f2a40879",
-                "sha256:d31402aad60ed889c7e57934a03477b572a03af7794fa8fb1780f21ea8f6551f",
-                "sha256:de96157ec73458a7f14e3d26f17f8128c959084931e8997b9e655a39c8fde9f9",
-                "sha256:df6b4dca2e11865e6cfbfb708e800efb18370f5a46fd601d3755bc7f85b3a8a2",
-                "sha256:ecadccc7ba52193963c0475ac9f6fa28ac01e01349a2ca48509667ef41ffd2cf",
-                "sha256:fb81c17e0ebe3358486cd8cc3ad78adbae58af12fc2bf2bc0bb84e8090fa5ce8"
+                "sha256:0cacd3ef5c604b8e5f59bf2582c076c98a37fe206b31430d0cd08138aff0986e",
+                "sha256:192ca04a36852a994ef21df13cca4d822adbbdc9d5009c0f96f1d2929e375d4f",
+                "sha256:19ae795137682a9778892fb4390c07811828b173741bce91e30f899424b3934d",
+                "sha256:1b9b535d6b55936a79dbe4990b64bb16048f48747c76c29713fea8c50eca2acf",
+                "sha256:2a2ad24d43398d89f92209289f15265107928f22a8d10385f70def7a698d6a02",
+                "sha256:3be7a5722d5bfe69894d3f7bbed15547b17619f3a88a318aab2e37f457524164",
+                "sha256:49870684da168b90110bbaf86140d4681032c5e6a2461adc7afdd93be5634216",
+                "sha256:587f98ce27ac4547177a0c6fe0986b8736058daffe9160dcf5f1bd411b7fbaa1",
+                "sha256:5aca6f00b2f42546b9bdf11a69f248d1881212ce5b9e2618b04935b87f6f82a1",
+                "sha256:6b744039b55988519cc183149cceb573189b3e46e16ccf6f8c46798bb767c9dc",
+                "sha256:6b91cab3841b4c7cb70e4db1697c69f036c8bc0a253edc0baa6783154f1301e4",
+                "sha256:7598974f6879a338c785c513e7c5a4329fbc58b9f6b9a6305035fca5b1076552",
+                "sha256:7a279f33a081d436e90e91d1a7c338553c04e464de1c9302311a5e7e4b746088",
+                "sha256:95e1296e0157361fe2f5f0ed307fd31f94b0ca13372e3673fa95095a627636a1",
+                "sha256:9fc9da390e98cb6975eadf251b6e5fa088820141061bf041cd5c72deba1dc526",
+                "sha256:cc20316e3f5a6b582fc3b029d8dc03aabeb645acfcb7fc1d9848841a33265748",
+                "sha256:d1bf5a1a0d60c7f9a78e448adcb99aa101f3f9588b16708044638881be15d6bc",
+                "sha256:ed1d0760c7e46436ec90834d6f10477ff09475c692ed1695329d324b2c5cd547",
+                "sha256:ef9a55013676907df6c9d7dd943eb1770d014f68beaa7e73250fb43c759f4585"
             ],
-            "version": "==2.8"
+            "version": "==2.9"
         },
         "idna": {
             "hashes": [
@@ -133,10 +131,11 @@
         },
         "mock": {
             "hashes": [
-                "sha256:3f9b2c0196c60d21838f307f5825a7b86b678cedc58ab9e50a8988187b4d81e0",
-                "sha256:dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f13867b2c56f72"
+                "sha256:83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3",
+                "sha256:d157e52d4e5b938c550f39eb2fd15610db062441a9c2747d3dbfa9298211d0f8"
             ],
-            "version": "==4.0.2"
+            "index": "pypi",
+            "version": "==3.0.5"
         },
         "parsedatetime": {
             "hashes": [
@@ -478,18 +477,18 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
-                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "version": "==2.4.6"
+            "version": "==2.4.7"
         },
         "pytest": {
             "hashes": [
-                "sha256:9f8d44f4722b3d06b41afaeb8d177cfbe0700f8351b1fc755dd27eedaa3eb9e0",
-                "sha256:f5d3d0e07333119fe7d4af4ce122362dc4053cdd34a71d2766290cf5369c64ad"
+                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
+                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
             ],
             "index": "pypi",
-            "version": "==5.3.3"
+            "version": "==5.4.1"
         },
         "rope": {
             "hashes": [


### PR DESCRIPTION
Attempt at pinning the mock version to 0.3.0.5 and the python version to 3.5.2 which should match the versions used in production.

**JIRA tickets**:  SE-2197

**Dependencies**: This is required for successful deployment of #11

**Testing instructions**:
With the version pinning in CircelCI config, those tests should should be sufficient.

**Reviewers**
- [x] @swalladge 
