### PR TITLE
Introduce certificate request delay

### DIFF
--- a/manage_certs.py
+++ b/manage_certs.py
@@ -44,6 +44,7 @@ def parse_command_line(args):
     parser.add_argument("--webroot-path", default="/var/www/certbot")
     parser.add_argument("--consul-token")
     parser.add_argument("--deploy-hook", default='/usr/local/sbin/deploy_cert.sh')
+    parser.add_argument("--dns-delay", type=int, default=120)
     return parser.parse_args(args)
 
 
@@ -64,6 +65,7 @@ def main(args):
         ConsulDomainConfiguration(config.consul_ocim_prefix, consul_client=consul_client),
         ConsulCertificateStorage(config.consul_certs_prefix, consul_client=consul_client),
         config.additional_domain,
+        dns_delay=config.dns_delay,
     )
     manager.run()
 


### PR DESCRIPTION
This change introduces an optional `dns_delay` parameter. It changes the expected output of domain configuration backend to include a timestamp of the time the DNS records were last set or updated in addition to the list of domains.

The certificate manager will NOT request new certificates for domains for which the DNS records were updated less than `dns_delay` seconds ago or were not yet set at all.

This is supposed to fix the problem where cert-manager requests certificates immediately Ocim where instance data is put into consul immediately after instance is created, but before DNS records are set.

This PR is part of [SE-2431](https://tasks.opencraft.com/browse/SE-2431) which also includes:
- https://github.com/open-craft/opencraft/pull/562
- https://github.com/open-craft/ansible-playbooks/pull/166