### PR TITLE
BB-2231: Add an option to send email alerts on certificate provisioning failures

### DIFF
--- a/cert_manager/__init__.py
+++ b/cert_manager/__init__.py
@@ -93,13 +93,12 @@ class CertificateManager:
         if self.failure_alert_email:
             from_address = '{}@{}'.format(pwd.getpwuid(os.getuid())[0], socket.gethostname())
             exception_msg = exception.stderr.decode('utf-8') if hasattr(exception, 'stderr') else str(exception)
-            email_message = """From: {}
-            To: {}
-            Subject: Alert: {}
-
-            Below is the exception:
-            {}
-            """.format(from_address, self.failure_alert_email, message.replace('\n', ''), exception_msg)
+            email_message = (
+                'From: {}\n'
+                'To: {}\n'
+                'Subject: Alert: {}\n\n'
+                'Below is the exception:\n{}'
+            ).format(from_address, self.failure_alert_email, message.replace('\n', ''), exception_msg)
             send_email(from_address, self.failure_alert_email, email_message)
 
     def get_current_domains(self):

--- a/cert_manager/__init__.py
+++ b/cert_manager/__init__.py
@@ -2,9 +2,12 @@
 
 from datetime import datetime
 import logging
+import os
+import pwd
+import socket
 import subprocess
 
-from .utils import extract_x509_dns_names
+from .utils import extract_x509_dns_names, send_email
 from .backends import StorageError
 
 
@@ -19,7 +22,7 @@ class CertificateManager:
     actions.
     """
     def __init__(self, certbot, domain_config, cert_storage, additional_domains,
-                 dns_delay=0, extract_x509_dns_names_func=extract_x509_dns_names):
+                 dns_delay=0, extract_x509_dns_names_func=extract_x509_dns_names, failure_alert_email=None):
         """Initialize a CertificateManager instance."""
         self.certbot = certbot
         self.domain_config = domain_config
@@ -27,6 +30,7 @@ class CertificateManager:
         self.dns_delay = dns_delay
         self.additional_domains = additional_domains
         self.extract_x509_dns_names = extract_x509_dns_names_func
+        self.failure_alert_email = failure_alert_email
 
     def remove_cert(self, main_domain):
         """Remove a certificate from both Certbot and the backend storage."""
@@ -36,20 +40,22 @@ class CertificateManager:
                 "Successfully deleted the certificate for %s from Certbot.", main_domain
             )
         except subprocess.CalledProcessError as exc:
+            message = "Failed to delete the certificate for %s from Certbot:\n%s"
             logger.error(
-                "Failed to delete the certificate for %s from Certbot:\n%s",
+                message,
                 main_domain,
                 exc.stderr,
             )
+            self.send_failure_alert_email(message % (main_domain, ''), exc)
         try:
             self.cert_storage.remove_cert(main_domain)
             logger.info(
                 "Successfully deleted the certificate for %s from the storage backend.", main_domain
             )
-        except StorageError:
-            logger.error(
-                "Failed to delete the certificate for %s from the storage backend.", main_domain
-            )
+        except StorageError as exc:
+            message = "Failed to delete the certificate for %s from the storage backend."
+            logger.error(message, main_domain)
+            self.send_failure_alert_email(message % (main_domain, ), exc)
 
     def request_cert(self, domains):
         """Request a new certificate using the Certbot client."""
@@ -60,17 +66,41 @@ class CertificateManager:
                 "\n    ".join(domains),
             )
         except subprocess.CalledProcessError as exc:
+            error_domains = "\n    ".join(domains)
+            message = (
+                "Failed to obtain a new certificate for these domains:\n    %s\n%s"
+            )
             logger.error(
-                "Failed to obtain a new certificate for these domains:\n    %s\n%s",
-                "\n    ".join(domains),
+                message,
+                error_domains,
                 exc.stderr,
             )
-        except Exception:  # pylint: disable=broad-except
-            logger.exception(
+            self.send_failure_alert_email(message % (error_domains, ''), exc)
+        except Exception as exc:  # pylint: disable=broad-except
+            message = (
                 "An exception occurred when trying to obtain a new certificate for these "
-                "domains:\n    %s",
-                "\n    ".join(domains),
+                "domains:\n    %s"
+                "\n    ".join(domains)
             )
+            logger.exception(message)
+            self.send_failure_alert_email(message, exc)
+
+    def send_failure_alert_email(self, message, exception):
+        """
+        If a failure alert email address is provided, send a failure alert email with the given message
+        and exception
+        """
+        if self.failure_alert_email:
+            from_address = '{}@{}'.format(pwd.getpwuid(os.getuid())[0], socket.gethostname())
+            exception_msg = exception.stderr.decode('utf-8') if hasattr(exception, 'stderr') else str(exception)
+            email_message = """From: {}
+            To: {}
+            Subject: Alert: {}
+
+            Below is the exception:
+            {}
+            """.format(from_address, self.failure_alert_email, message.replace('\n', ''), exception_msg)
+            send_email(from_address, self.failure_alert_email, email_message)
 
     def get_current_domains(self):
         """Return the domain names of all certificates in the storage backend.

--- a/cert_manager/utils.py
+++ b/cert_manager/utils.py
@@ -1,8 +1,10 @@
 """Utility functions for the certificate manager."""
 
 import logging.handlers
+import smtplib
 
 import OpenSSL.crypto
+
 
 def extract_x509_dns_names(pem_data):
     """Extract the DNS names from the given PEM certificate."""
@@ -32,3 +34,9 @@ def configure_logger(logger_, log_level):
     stderr_handler = logging.StreamHandler()
     stderr_handler.setLevel(logging.ERROR)
     logger_.addHandler(stderr_handler)
+
+
+def send_email(from_address, to_addresses, message, mail_server='localhost'):
+    """Send email using locally setup mailserver"""
+    smtp = smtplib.SMTP(mail_server)
+    smtp.sendmail(from_address, to_addresses, message)

--- a/manage_certs.py
+++ b/manage_certs.py
@@ -11,7 +11,6 @@ Certificates are requested using Certbot.
 
 import argparse
 import logging
-import pathlib
 import sys
 
 import consul
@@ -45,6 +44,7 @@ def parse_command_line(args):
     parser.add_argument("--consul-token")
     parser.add_argument("--deploy-hook", default='/usr/local/sbin/deploy_cert.sh')
     parser.add_argument("--dns-delay", type=int, default=120)
+    parser.add_argument('--failure-alert-email', default=None)
     return parser.parse_args(args)
 
 
@@ -52,7 +52,6 @@ def main(args):
     """Parse command line, run certificate manager."""
     config = parse_command_line(args)
     configure_logger(logger, config.log_level.upper())
-    cert_manager_dir = str(pathlib.Path(__file__).resolve().parent)
     certbot_client = CertbotClient(
         contact_email=config.contact_email,
         webroot_path=config.webroot_path,
@@ -66,6 +65,7 @@ def main(args):
         ConsulCertificateStorage(config.consul_certs_prefix, consul_client=consul_client),
         config.additional_domain,
         dns_delay=config.dns_delay,
+        failure_alert_email=config.failure_alert_email
     )
     manager.run()
 


### PR DESCRIPTION
This PR adds a new command-line parameter `--failure-alert-email` which sends email to the argument provided to the said parameter whenever a failure occurs during provisioning of certificate.