### PR TITLE
[SE-3777] Use different strategy to clean unneeded certificates.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,10 @@ jobs:
       - run:
           name: Install python3 and pip3
           command: apt-get update && apt-get install -y python3 python3-pip
-      - run: 
+      - run:
+          name: Install virtualenv version which is compatible with python 3.5
+          command: pip3 install --user virtualenv==v20.0.21
+      - run:
           name: Install pipenv locally
           command: pip3 install --user pipenv
       - restore_cache:

--- a/cert_manager/__init__.py
+++ b/cert_manager/__init__.py
@@ -121,7 +121,7 @@ class CertificateManager:
         for main_domain, domain_group in configured_domains.items():
             # Check if at least some of the domains are not covered by the current certificate
             domains = domain_group['domains']
-            if set(domains) - current_domains.get(main_domain, set()):
+            if set(domains) != set(current_domains.get(main_domain, [])):
                 # Request new certificates, but only if DNS records for the domain have already
                 # been set, *and* they have been set more than a preconfigured number of seconds ago
                 # to allow the changes to propagate.
@@ -133,12 +133,9 @@ class CertificateManager:
     def remove_unneeded(self, configured_domains, current_domains):
         """Remove unneeded certificates from the backend storage."""
         all_domains = set()
-        for main_domain, domain_group in configured_domains.items():
-            if domain_group['dns_records_updated'] is not None:
-                all_domains.update(domain_group['domains'])
-        for main_domain, dns_names in current_domains.items():
-            if dns_names.isdisjoint(all_domains):
-                # The certificate isn't needed for any of the currently active domains
+        for main_domain in current_domains.keys():
+            domain_group = configured_domains.get(main_domain, None)
+            if domain_group is None or domain_group['dns_records_updated'] is None:
                 self.remove_cert(main_domain)
 
     def run(self):


### PR DESCRIPTION
This changes the way certificates are provisioned in cleaned up on the cert-manager server.

For historical reasons we used to check whether for any certificate file whether any of its "Subject Alt Names" were still used by some of the instances, and would not remove it if they were. This is problematic because it leaves us with duplicate certificates, for example when adding an external domain name to an instance that previously didn't use external domains. That causes the main domain of the instance to change, which in effect changes the filename of the certificate that certbot creates and we end up with duplicate certificates.

This changes ensures that all certificates are named after the main domain of their instance and that any certificates with names that don't match any instances are removed.

**Test instructions**:

The changes have been deployed to `cert-manager-stage.net.opencraft.hosting` so that testing can be done in the stage environment.

1. Create a new instance in Ocim stage (the easiest way is to use [`production_instance_factory`](https://ocim.opencraft.com/en/latest/provisioning-sandboxes/#manual-provisioning) . Pick an internal subomain, but don't use any external domains yet. Wait for the first appserver to provision successfully.
2. Visit the LMS URL of your test instance in the browser. You'll get an untrusted certificate warning because Ocim stage uses Let's Encrypt stage, which uses a CA that isn't trusted by browsers. Bypass the warning - how to do that depends on the browser. In Firefox it's as easy as clicking the "Accept the risk and continue" button.
3. Once on the LMS page, view the SSL certificate in your browser. In FF you can do that by clicking the lock icon in the URL bar, clicking the right arrow to "Show connection details", click "More information", switch to the "Security" tab, then click the "View Certificate" button.
4. Look at the "Subject Alt Names" property. It should contain all internal DNS entries for the instance (LMS, Studio, preview, discovery, ecommerce).
5. SSH into `cert-manager-stage.net.opencraft.hosting` and run `sudo ls /etc/letsencrypt/live`. That's the folder where certificates managed by certbot are located. You should see a certificate named after your internal LMS domain (ie. `<subdomain>.stage.opencraft.hosting`.
6. Modify your instance in Ocim to change some of the internal subdomains, but don't change the LMS subdomain (Ocim currently assumes the internal LMS subdomain never changes).
7. Spawn a new appserver to trigger DNS setup in gandi to be updated. Note that you have to spawn a new appserver, but you don't have to wait for the new appserver to finish building, you only need to wait a few minutes for the DNS to get updated and a new certificate provisioned.
8. Visit the LMS in your browser again, and view the certificate. Note that browsers sometimes cache certificates, so you might have to do some hard refreshing. The changes you made to internal subdomains should be reflected in certificate's "Subject Alt Names" entry.
9. On `cert-manager-stage`, verify that the name of your instance's certificate in `/etc/letsencrypt/live` is unchanged and no additional certificate associated with your instance was created.
10. Now go back to your instance in Ocim and add an external domain. You can use either a domain you own or a subdomain of `plebia.net` (you can find Gandi credentials in Vault). You'll have to set CNAME DNS entries for all five endpoints (LMS, Studio, preview, discovery, ecommerce) and point them to `haproxy-stage.opencraft.hosting`.
11. Wait some time for the DNS changes to propagate.
12. Spawn a new appserver to trigger DNS and certificate update. Wait a few minutes.
13. Go to the external URL of the LMS, and view the certificate. Verify that the "Subject Alt Names" field contains 10 entries (5 internal + 5 external domains.
14. On `cert-manager-stage`, make sure that the old certificate (named after the internal domain) no longer exist in `/etc/letsencrypt/live` and that a new certificate (named after the external domain) does exist.